### PR TITLE
public sector employee rather than civil servant

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -420,10 +420,8 @@
 
   <p>
     Your name is an integral part of your request, so has to be published with
-    it. It is only fair, as we are also going to publish the name of the civil
-    servant who writes the response to your request. Using your real name also
-    helps people get in touch with you to assist you with your research or to
-    campaign with you.
+    it. It is only fair, as we are also going to publish the name of the public sector employee who writes the response to your request. 
+    Using your real name also helps people get in touch with you to assist you with your research or to campaign with you.
   </p>
   <p>
     But perhaps most importantly, it means that our users think twice before


### PR DESCRIPTION

## Relevant issue(s)
Technically, the term civil servant excludes people working the military, the police, the health service, local government, the Royal Household and Parliament. I am suggesting we use "public sector employee" instead in our help text.

## What does this do?
See above.

## Why was this needed?
See above.

## Implementation notes
N/A.

## Screenshots
N/A.

## Notes to reviewer
N/A.